### PR TITLE
Fix for neighboring like tags leaking markdown text

### DIFF
--- a/html2markdown.js
+++ b/html2markdown.js
@@ -228,7 +228,11 @@ function html2markdown(html, opts) {
 			case "dfn":
 			case "var":
 			case "cite":
-				nodeList.push(markdownTags[tag]);
+				if (nodeList[nodeList.length-1] === markdownTags[tag]) {
+					nodeList.splice(nodeList.length-1, 1);
+				} else {
+					nodeList.push(markdownTags[tag]);
+				}
 				break;
 			case "code":
 			case "span":


### PR DESCRIPTION
Previously,  neighboring like tags would cause leaking markdown text. For example, in "abcdefg", if a user selected "abc" and made it bold, then selected the "defg" and made it bold, it would leak "_" around the "defg", because the markdown would look like *_abc*_**defg__. With this PR, it will remove the last closing tag if the new opening tag is the same, and put the new contents inside the last tag.
So in the example, it would create *_abcdefg**
